### PR TITLE
Use scheme consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ $parser = new Parser();
 $parser->parseUrl($urlString);
 
 echo $parser->getHost(); // www.example.com
-echo $parser->getSchema(); // http
+echo $parser->getScheme(); // http
 echo $parser->getAuthority(); // john.doe@www.example.com:123
 
 // you can also do
 echo Parser::from($urlString)->getHost(); // www.example.com
-echo Parser::from($urlString)->getSchema(); // http
+echo Parser::from($urlString)->getScheme(); // http
 echo Parser::from($urlString)->getAuthority(); // john.doe@www.example.com:123
 
 ````

--- a/src/AbstractUrl.php
+++ b/src/AbstractUrl.php
@@ -28,7 +28,7 @@ abstract class AbstractUrl
     /**
      * @var array
      */
-    protected $allowedSchemas
+    protected $allowedSchemes
         = [
             'http',
             'https',
@@ -38,7 +38,7 @@ abstract class AbstractUrl
     /**
      * @var
      */
-    protected $schema = null;
+    protected $scheme = null;
 
     /**
      * @var

--- a/src/Builder/Builder.php
+++ b/src/Builder/Builder.php
@@ -6,7 +6,7 @@ namespace Keppler\Url\Builder;
 use Keppler\Url\AbstractUrl;
 use Keppler\Url\Builder\Bags\PathBag;
 use Keppler\Url\Builder\Bags\QueryBag;
-use Keppler\Url\Exceptions\SchemaNotSupportedException;
+use Keppler\Url\Exceptions\SchemeNotSupportedException;
 use Keppler\Url\Parser\Parser;
 
 /**
@@ -47,7 +47,7 @@ class Builder extends AbstractUrl
         $self->path = new PathBag();
 
         $self->original = $parser->getOriginal();
-        $self->schema = $parser->getSchema();
+        $self->scheme = $parser->getScheme();
         $self->authority = $parser->getAuthority();
         $self->fragment = $parser->getFragment();
         $self->username = $parser->getUsername();
@@ -65,15 +65,15 @@ class Builder extends AbstractUrl
      * @param string $scheme
      *
      * @return Builder
-     * @throws SchemaNotSupportedException
+     * @throws SchemeNotSupportedException
      */
     public function setScheme(string $scheme): self
     {
-        if ( ! in_array($scheme, $this->allowedSchemas)) {
-            throw new SchemaNotSupportedException("The scheme is not supported");
+        if ( ! in_array($scheme, $this->allowedSchemes)) {
+            throw new SchemeNotSupportedException("The scheme is not supported.");
         }
 
-        $this->schema = $scheme;
+        $this->scheme = $scheme;
 
         return $this;
     }
@@ -175,11 +175,11 @@ class Builder extends AbstractUrl
     {
         $url = '';
 
-        if (null === $this->schema || null === $this->host) {
-            throw new \LogicException("At least the schema and the host must be present.");
+        if (null === $this->scheme || null === $this->host) {
+            throw new \LogicException("At least the scheme and the host must be present.");
         }
 
-        $url .= $this->schema.'://';
+        $url .= $this->scheme.'://';
         $url .= $this->buildAuthority();
         $url .= $this->path->raw($withTrailingSlash);
         $url .= $this->query->raw();

--- a/src/Exceptions/SchemeNotSupportedException.php
+++ b/src/Exceptions/SchemeNotSupportedException.php
@@ -3,4 +3,4 @@ declare(strict_types=1);
 
 namespace Keppler\Url\Exceptions;
 
-class SchemaNotSupportedException extends \Exception{};
+class SchemeNotSupportedException extends \Exception{};

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -7,7 +7,7 @@ use Keppler\Url\AbstractUrl;
 use Keppler\Url\Parser\Bags\PathBag;
 use Keppler\Url\Parser\Bags\QueryBag;
 use Keppler\Url\Exceptions\MalformedUrlException;
-use Keppler\Url\Exceptions\SchemaNotSupportedException;
+use Keppler\Url\Exceptions\SchemeNotSupportedException;
 
 /**
  * Immutable Class Parser
@@ -40,7 +40,7 @@ class Parser extends AbstractUrl
      *
      * @return Parser
      * @throws MalformedUrlException
-     * @throws SchemaNotSupportedException
+     * @throws SchemeNotSupportedException
      */
     public static function from(string $url): self
     {
@@ -57,24 +57,24 @@ class Parser extends AbstractUrl
      * @param string $url
      *
      * @throws MalformedUrlException
-     * @throws SchemaNotSupportedException
+     * @throws SchemeNotSupportedException
      */
     public function parseUrl(string $url): void
     {
         $parsedUrl = parse_url($url);
 
         if ( ! isset($parsedUrl['scheme'])) {
-            throw new MalformedUrlException("Missing scheme");
+            throw new MalformedUrlException("Missing scheme.");
         }
 
-        $schemaFromUrl = $parsedUrl['scheme'];
-        if ( ! in_array($schemaFromUrl, $this->allowedSchemas)) {
-            throw new SchemaNotSupportedException(vsprintf("Scheme not allowed. Only %s, %s, and %s are supported. If you need additional schemas extend this class and roll your own implementation.",
-                $this->allowedSchemas));
+        $schemeFromUrl = $parsedUrl['scheme'];
+        if ( ! in_array($schemeFromUrl, $this->allowedSchemes)) {
+            throw new SchemeNotSupportedException(vsprintf("Scheme not allowed. Only %s, %s, and %s are supported. If you need additional schemes extend this class and roll your own implementation.",
+                $this->allowedSchemes));
         }
 
         $this->original = $url;
-        $this->schema = $parsedUrl['scheme'] ?? null;
+        $this->scheme = $parsedUrl['scheme'] ?? null;
         $this->host = $parsedUrl['host'] ?? null;
         $this->port = $parsedUrl['port'] ?? null;
         $this->username = $parsedUrl['user'] ?? null;
@@ -145,7 +145,7 @@ class Parser extends AbstractUrl
     public function all(): array
     {
         return [
-            'schema'    => $this->schema,
+            'scheme'    => $this->scheme,
             'host'      => $this->host,
             'authority' => $this->authority,
             'path'      => $this->path->all(),
@@ -178,9 +178,9 @@ class Parser extends AbstractUrl
     /**
      * @return null|string
      */
-    public function getSchema(): ?string
+    public function getScheme(): ?string
     {
-        return $this->schema;
+        return $this->scheme;
     }
 
     /**

--- a/tests/Builder/BuilderTest.php
+++ b/tests/Builder/BuilderTest.php
@@ -6,7 +6,7 @@ use Keppler\Url\Builder\Bags\PathBag;
 use Keppler\Url\Builder\Bags\QueryBag;
 use Keppler\Url\Builder\Builder;
 use Keppler\Url\Exceptions\MalformedUrlException;
-use Keppler\Url\Exceptions\SchemaNotSupportedException;
+use Keppler\Url\Exceptions\SchemeNotSupportedException;
 use Keppler\Url\Parser\Parser;
 use PHPUnit\Framework\TestCase;
 
@@ -28,15 +28,15 @@ class BuilderTest extends TestCase
         $this->assertInstanceOf(QueryBag::class, $builder->query);
     }
 
-    public function test_invalid_schema()
+    public function test_invalid_scheme()
     {
-        $this->expectException(SchemaNotSupportedException::class);
+        $this->expectException(SchemeNotSupportedException::class);
 
         $builder = new Builder();
-        $builder->setScheme('invalid_schema');
+        $builder->setScheme('invalid_scheme');
     }
 
-    public function test_build_without_schema_or_host()
+    public function test_build_without_scheme_or_host()
     {
         $this->expectException(\LogicException::class);
 

--- a/tests/Parser/ParserTest.php
+++ b/tests/Parser/ParserTest.php
@@ -5,7 +5,7 @@ namespace Keppler\Parser\Tests;
 use Keppler\Url\Parser\Bags\PathBag;
 use Keppler\Url\Parser\Bags\QueryBag;
 use Keppler\Url\Exceptions\MalformedUrlException;
-use Keppler\Url\Exceptions\SchemaNotSupportedException;
+use Keppler\Url\Exceptions\SchemeNotSupportedException;
 use Keppler\Url\Parser\Parser;
 use PHPUnit\Framework\TestCase;
 
@@ -18,9 +18,9 @@ class ParserTest extends TestCase
         Parser::from(''); // pass in a malformed url
     }
 
-    public function test_should_throw_schema_not_supported_exception()
+    public function test_should_throw_scheme_not_supported_exception()
     {
-        $this->expectException(SchemaNotSupportedException::class);
+        $this->expectException(SchemeNotSupportedException::class);
 
         Parser::from('news:comp.infosystems.www.servers.unix');
     }
@@ -39,25 +39,25 @@ class ParserTest extends TestCase
         $this->assertInstanceOf(QueryBag::class, $parser->query);
     }
 
-    public function test_should_have_schema_https()
+    public function test_should_have_scheme_https()
     {
         $parser = Parser::from('https://john.doe@www.example.com:123/forum/questions/?tag=networking&order=newest#top');
 
-        $this->assertEquals('https', $parser->getSchema());
+        $this->assertEquals('https', $parser->getScheme());
     }
 
-    public function test_should_have_schema_http()
+    public function test_should_have_scheme_http()
     {
         $parser = Parser::from('http://john.doe@www.example.com:123/forum/questions/?tag=networking&order=newest#top');
 
-        $this->assertEquals('http', $parser->getSchema());
+        $this->assertEquals('http', $parser->getScheme());
     }
 
-    public function test_should_have_schema_mailto()
+    public function test_should_have_scheme_mailto()
     {
         $parser = Parser::from('mailto:John.Doe@example.com');
 
-        $this->assertEquals('mailto', $parser->getSchema());
+        $this->assertEquals('mailto', $parser->getScheme());
     }
 
     public function test_should_full_authority()


### PR DESCRIPTION
The inconsistent mixed usage of  `schema` and `scheme` is confusing. Refactored to use `scheme` everywhere.